### PR TITLE
Extract Release version for Manjaro OS

### DIFF
--- a/src/sources/linux/os-lsb-release.sh
+++ b/src/sources/linux/os-lsb-release.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env kmd
 exec lsb_release -a
-extract \nDISTRIB_RELEASE=\s*([\d\.]+)[^\n]*\n
+extract \nRelease=\s*([\d\.]+)[^\n]*\n
 save system.lsb_version


### PR DESCRIPTION
Extract Release version from  Manjaro OS

```
Distributor ID:	Manjaro
Description:	Ubuntu 20.04.5 LTS
Release:	20.04
Codename:	focal
```