### PR TITLE
fix react warnings

### DIFF
--- a/public/style/globals.css
+++ b/public/style/globals.css
@@ -459,6 +459,10 @@ svg {
   line-height: 1rem;
 }
 
+.text-underline {
+  text-decoration-line: underline;
+}
+
 .font-extralight {
   font-weight: 200;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -447,7 +447,8 @@ class App extends Component {
     }
   };
 
-  handleShowDescription = () => {
+  handleShowDescription = (e) => {
+    e.preventDefault()
     this.setState({
       showDescription: !this.state.showDescription,
     });

--- a/src/App.js
+++ b/src/App.js
@@ -447,8 +447,8 @@ class App extends Component {
     }
   };
 
-  handleShowDescription = (e) => {
-    e.preventDefault()
+  handleShowDescription = (event) => {
+    event.preventDefault()
     this.setState({
       showDescription: !this.state.showDescription,
     });

--- a/src/Device.js
+++ b/src/Device.js
@@ -376,8 +376,8 @@ class Device extends Component {
     });
   };
 
-  showWelcomeDescription = (e) => {
-    e.preventDefault()
+  showWelcomeDescription = (event) => {
+    event.preventDefault()
     this.setState({
       showDescription: !this.state.showDescription,
     });

--- a/src/Device.js
+++ b/src/Device.js
@@ -33,10 +33,9 @@ const WelcomeMessage = ({ name, showWelcomeDescription, showDescription }) => {
       </p>
       <p>
         <a
-          className={`text-xs cursor-pointer  ${
+          className={`text-xs cursor-pointer text-underline ${
             showDescription ? "open" : "closed"
           }`}
-          href="javascript:void(0)"
           type="button"
           onClick={showWelcomeDescription}
         >
@@ -377,7 +376,8 @@ class Device extends Component {
     });
   };
 
-  showWelcomeDescription = () => {
+  showWelcomeDescription = (e) => {
+    e.preventDefault()
     this.setState({
       showDescription: !this.state.showDescription,
     });

--- a/src/components/ConnectToSprintoApp.js
+++ b/src/components/ConnectToSprintoApp.js
@@ -15,11 +15,10 @@ const WelcomeMessage = ({ onClickShowDescription, showDescription }) => {
       </div>
       <p className="mt-6">
         <a
-          className={`text-xs cursor-pointer ${
+          className={`text-xs cursor-pointer text-underline ${
             showDescription ? "open" : "closed"
           }`}
           type="button"
-          href="javascript:void(0)"
           onClick={onClickShowDescription}
         >
           What will be shared with Sprinto?

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,5 @@ const root = createRoot(node);
 root.render(
   <ErrorBoundary>
     <App />
-  </ErrorBoundary>,
-  node
+  </ErrorBoundary>
 );


### PR DESCRIPTION
Fix the following two warnings:

- ```"Warning: You passed a container to the second argument of root.render(...). You don't need to pass it again since you already passed it to create the root.", source: http://127.0.0.1:12000/static/js/bundle.js (51285)```
- ```"Warning: A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML try using dangerouslySetInnerHTML instead. React was passed %s.%s "javascript:void(0)```