### PR TITLE
add individual build and upload to s3

### DIFF
--- a/.github/workflows/os_build.yml
+++ b/.github/workflows/os_build.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build-and-package-macos:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'macos' }}
+    outputs: 
+      version_number: ${{ steps.extract_version.outputs.version}}
     runs-on: macos-latest
     
     steps:
@@ -51,9 +53,15 @@ jobs:
         with:
           name: Dist-macos
           path: dist
+          
+      - name: Get version from package.json
+        id: extract_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT  
   
   build-and-package-ubuntu:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'ubuntu' }}
+    outputs: 
+      version_number: ${{ steps.extract_version.outputs.version}}
     runs-on: ubuntu-latest
     
     steps:
@@ -94,10 +102,17 @@ jobs:
         with:
           name: Dist-ubuntu
           path: dist
+      
+      - name: Get version from package.json
+        id: extract_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT  
+
 
   build-and-package-windows:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'windows' }}
-    runs-on: windows-latest
+    outputs: 
+      version_number: ${{ steps.extract_version.outputs.version}}
+    runs-on: macos-latest
     
     steps:
       - name: Checkout code
@@ -133,6 +148,11 @@ jobs:
         with:
           name: Dist-windows
           path: dist
+          
+      - name: Get version from package.json
+        id: extract_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT  
+  
   
   upload-to-s3-ubuntu:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'ubuntu' }} 
@@ -156,15 +176,12 @@ jobs:
           pattern: Dist-*
           merge-multiple: true
           
-      - name: Extract version number
-        id: extract_version
-        run: echo "version=$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
-        
+              
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
             cp dist/*.{yml,AppImage} artifacts/ && \
-            aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 
+            aws s3 sync artifacts s3://drsprinto-build/${{ needs.build-and-package-ubuntu.outputs.version_number }}/  
             
   upload-to-s3-windows:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'windows' }} 
@@ -188,15 +205,11 @@ jobs:
           pattern: Dist-*
           merge-multiple: true
           
-      - name: Extract version number
-        id: extract_version
-        run: echo "version=$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
-        
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
             cp dist/*.{yml,exe} artifacts/ && \
-            aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 
+            aws s3 sync artifacts s3://drsprinto-build/${{ needs.build-and-package-windows.outputs.version_number }}/  
             
   upload-to-s3-macos:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'macos' }} 
@@ -220,12 +233,8 @@ jobs:
           pattern: Dist-*
           merge-multiple: true      
           
-      - name: Extract version number
-        id: extract_version
-        run: echo "version=$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
-        
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
             cp dist/*.{yml,dmg} artifacts/ && \
-            aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 
+            aws s3 sync artifacts s3://drsprinto-build/${{ needs.build-and-package-macos.outputs.version_number }}/

--- a/.github/workflows/os_build.yml
+++ b/.github/workflows/os_build.yml
@@ -7,9 +7,14 @@ on:
         description: Branch name of Stethoscope Repository
         required: true
         type: string
+      build_type:
+        description: Type of build to generate & upload
+        required: true
+        type: string
 
 jobs:
   build-and-package-macos:
+    if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'macos' }}
     runs-on: macos-latest
     
     steps:
@@ -48,6 +53,7 @@ jobs:
           path: dist
   
   build-and-package-ubuntu:
+    if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'ubuntu' }}
     runs-on: ubuntu-latest
     
     steps:
@@ -90,6 +96,7 @@ jobs:
           path: dist
 
   build-and-package-windows:
+    if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'windows' }}
     runs-on: windows-latest
     
     steps:
@@ -116,10 +123,6 @@ jobs:
             ${{ runner.home }}/.cache/electron-builder
           key: windows-latest-dependencies-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Cleanup old cache
-        if: runner.os == 'ubuntu-latest'
-        run: rm -rf ${{ runner.home }}/.cache/electron-builder/wine
-
       - name: Build and Package for Windows
         run: |
           yarn build:windows
@@ -130,13 +133,14 @@ jobs:
         with:
           name: Dist-windows
           path: dist
-
-  upload-to-s3:
+  
+  upload-to-s3-ubuntu:
+    if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'ubuntu' }} 
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
-    needs: [build-and-package-macos, build-and-package-ubuntu, build-and-package-windows]
+    needs: [build-and-package-ubuntu]
     
     steps:
       - name: Configure AWS
@@ -151,14 +155,77 @@ jobs:
           path: dist
           pattern: Dist-*
           merge-multiple: true
-
-      
+          
+      - name: Extract version number
+        id: extract_version
+        run: echo "::set-output name=version::$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)"
   
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
-            cp dist/*.{yml,exe,dmg,AppImage} artifacts/ && \
-            aws s3 sync artifacts s3://drsprinto-build/${{ github.event.inputs.stethoscope_repo_branch_name }}
-      
+            cp dist/*.{yml,AppImage} artifacts/ && \
+            aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 
+            
+  upload-to-s3-windows:
+    if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'windows' }} 
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: [build-and-package-windows]
+    
+    steps:
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::426216900398:role/github-actions-sprinto-repo-role
+          aws-region: us-west-1
+    
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: Dist-*
+          merge-multiple: true
+          
+      - name: Extract version number
+        id: extract_version
+        run: echo "::set-output name=version::$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)"
   
+      - name: Push artifacts to S3
+        run: |
+            mkdir artifacts && \
+            cp dist/*.{yml,exe} artifacts/ && \
+            aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 
+            
+  upload-to-s3-macos:
+    if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'macos' }} 
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    needs: [build-and-package-macos]
+    
+    steps:
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::426216900398:role/github-actions-sprinto-repo-role
+          aws-region: us-west-1
+    
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: Dist-*
+          merge-multiple: true      
+          
+      - name: Extract version number
+        id: extract_version
+        run: echo "::set-output name=version::$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)"
   
+      - name: Push artifacts to S3
+        run: |
+            mkdir artifacts && \
+            cp dist/*.{yml,AppImage} artifacts/ && \
+            aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 

--- a/.github/workflows/os_build.yml
+++ b/.github/workflows/os_build.yml
@@ -227,5 +227,5 @@ jobs:
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
-            cp dist/*.{yml,AppImage} artifacts/ && \
+            cp dist/*.{yml,dmg} artifacts/ && \
             aws s3 sync artifacts s3://drsprinto-build/${{ steps.extract_version.outputs.version }}/ 

--- a/.github/workflows/os_build.yml
+++ b/.github/workflows/os_build.yml
@@ -158,8 +158,8 @@ jobs:
           
       - name: Extract version number
         id: extract_version
-        run: echo "::set-output name=version::$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)"
-  
+        run: echo "version=$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+        
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
@@ -190,8 +190,8 @@ jobs:
           
       - name: Extract version number
         id: extract_version
-        run: echo "::set-output name=version::$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)"
-  
+        run: echo "version=$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+        
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \
@@ -222,8 +222,8 @@ jobs:
           
       - name: Extract version number
         id: extract_version
-        run: echo "::set-output name=version::$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)"
-  
+        run: echo "version=$(echo ${{ github.event.inputs.stethoscope_repo_branch_name }} | cut -d'/' -f3)" >> $GITHUB_OUTPUT
+        
       - name: Push artifacts to S3
         run: |
             mkdir artifacts && \


### PR DESCRIPTION
This PR accomplishes two tasks 
1) Specific OS Build:
We can now specify our desired operating system for the build process using the build_type input parameter. This parameter accepts four values: all, macos, ubuntu, and windows.
The workflow has been changed to execute separate upload jobs for each operating system. This enables parallelism, ensuring faster artifact uploads without waiting for the completion of other build tasks.

2) Storing in version number folder in s3 
Artifacts generated during the build process are now stored in version-numbered folders within the designated S3 bucket. For example, artifacts for version 4.0.7 of the Stethoscope application will be stored in the s3://drsprinto-build/4.0.7 directory. Version number is picked up from package.json
