### PR TITLE
Adding windows signing

### DIFF
--- a/.github/workflows/os_build.yml
+++ b/.github/workflows/os_build.yml
@@ -112,7 +112,7 @@ jobs:
     if: ${{ github.event.inputs.build_type == 'all' || github.event.inputs.build_type == 'windows' }}
     outputs: 
       version_number: ${{ steps.extract_version.outputs.version}}
-    runs-on: macos-latest
+    runs-on: windows-latest
     
     steps:
       - name: Checkout code
@@ -142,6 +142,48 @@ jobs:
         run: |
           yarn build:windows
           
+      - name: Sign
+        shell: powershell
+        env:
+          WINDOZE_CERT_DATA: ${{ secrets.P12FILE }}
+          WINDOZE_CERT_PASSWORD: ${{ secrets.PASSWORD }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          # Get some things for cert opts
+          $version = (Get-Content package.json | ConvertFrom-Json).version
+          $file = -join($pwd, "/", "dist/DrSprinto Setup ",$version,".exe");
+          $temp_dir = $env:TMP
+          $cert_data = $env:WINDOZE_CERT_DATA
+          $cert_path = "$temp_dir\lando.windoze.p12"
+          $cert_password = $env:WINDOZE_CERT_PASSWORD
+          $cert_secure_password = $null
+          $signtool = "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64\signtool.exe"
+          $signtool2022 = "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe"
+          # Throw error if file does not exist
+          if (!(Test-Path "$file"))
+          {
+            throw "$file does not exist"
+          }
+          # Decode and dump to temp file
+          If (!(Test-Path $cert_path)) {
+            Write-Output "Dumping cert to $cert_path..."
+            $bytes = [Convert]::FromBase64String($cert_data)
+            [IO.File]::WriteAllBytes($cert_path, $bytes)
+          }
+          # Use more recent signtool if we can
+          If (Test-Path $signtool2022) {
+            $signtool = "$signtool2022"
+          }
+          # Verify the cert and password are good
+          Write-Output "Verifying cert is good to go..."
+          $cert_secure_password = ConvertTo-SecureString $cert_password -AsPlainText -Force
+          Import-PfxCertificate -FilePath "$cert_path" -Password $cert_secure_password -CertStoreLocation "Cert:\LocalMachine\My"
+          # If we get this far we should be good!
+          Write-Output "We can sign!"
+          # Sign
+          Write-Output "Trying to sign $file with $signtool..."
+          & $signtool sign -f "$cert_path" -p "$cert_password" -fd sha256 /sha1 ${{ secrets.SHA1KEY }} -tr "http://timestamp.comodoca.com/?td=sha256" -td sha256 $env:OPTIONS -as -v "$file"
+        
         
       - name: Save artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Description:
This pull request adds code signing functionality for Windows executables generated through github action. 

Code Signing Script:
I've introduced a PowerShell script to handle the code signing process for Windows executables.
The script retrieves the necessary certificate data and password from GitHub secrets.
It extracts the version number from the package.json file to ensure that the signed executable reflects the correct version.
The script checks for the existence of the executable file and throws an error if it doesn't exist.
It decodes the certificate data and saves it to a temporary file.
The script verifies the certificate and password before proceeding with the signing process.
Finally, it uses the signtool.exe utility to sign the executable with the specified options, including the SHA1 key and timestamp server.
Reference github action- https://github.com/lando/code-sign-action/blob/main/action.yml