### PR TITLE
added script to remove rpath which exploit vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "directories": {
       "buildResources": "public"
     },
+    "afterPack": "scripts/remove-rpath.js",
     "files": [
       "bitlocker-status/*",
       "build/**",

--- a/scripts/remove-rpath.js
+++ b/scripts/remove-rpath.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function isELF(filePath) {
+  const output = execSync(`file "${filePath}"`).toString();
+  return output.includes('ELF');
+}
+
+function removeRpath(filePath) {
+  try {
+    const result = execSync(`chrpath -l "${filePath}"`, { stdio: 'pipe' }).toString();
+    if (result.includes('RPATH')) {
+      execSync(`chrpath -d "${filePath}"`);
+      console.log(`Removed RPATH from: ${filePath}`);
+    }
+  } catch (err) {
+    // chrpath returns error if no RPATH found — ignore
+  }
+}
+
+function walk(dir) {
+  const files = fs.readdirSync(dir);
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    const stat = fs.statSync(filePath);
+
+    if (stat.isDirectory()) {
+      walk(filePath);
+    } else if (stat.isFile() && isELF(filePath)) {
+      removeRpath(filePath);
+    }
+  }
+}
+
+exports.default = async function (context) {
+  const appPath = context.appOutDir;
+  console.log(`Scanning for ELF binaries in: ${appPath}`);
+  walk(appPath);
+};

--- a/scripts/remove-rpath.js
+++ b/scripts/remove-rpath.js
@@ -35,6 +35,11 @@ function walk(dir) {
 
 exports.default = async function (context) {
   const appPath = context.appOutDir;
-  console.log(`Scanning for ELF binaries in: ${appPath}`);
-  walk(appPath);
+  if(context.electronPlatformName === 'linux') {
+    console.log(`Scanning for ELF binaries in: ${appPath}`);
+    walk(appPath);
+  }
+  else {
+    console.log('skipping non-linux platform ', context.electronPlatformName);
+  }
 };


### PR DESCRIPTION
The "RPATH Misconfiguration Leading to Shared Object Hijacking" vulnerability in Electron apps on Linux typically arises due to how dynamic libraries (shared objects) are loaded when your application starts.

To remove RPATH from binaries during the EThe "RPATH Misconfiguration Leading to Shared Object Hijacking" vulnerability in Electron applications on Linux usually occurs because of the way dynamic libraries (shared objects) are loaded when the application starts.

