### PR TITLE
add .deb target for linux build

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+        "AppImage", "deb"
       ],
       "maintainer": "Sprinto",
       "icon": "build/drsprinto-icons",


### PR DESCRIPTION
add .deb target to support >= ubuntu 24.04 as the AppImage does not work with this version of ubuntu